### PR TITLE
ci: notify sepal-apps-catalog on release

### DIFF
--- a/.github/workflows/notify-catalog.yml
+++ b/.github/workflows/notify-catalog.yml
@@ -1,0 +1,52 @@
+name: Notify catalog of release
+
+on:
+  release:
+    types: [published]
+
+env:
+  CATALOG_REPO: dfguerrerom/sepal-apps-catalog
+  APP_ID: sepal_mgci
+  APP_REPOSITORY: https://github.com/sepal-contrib/sepal_mgci
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Resolve tag to 40-char commit SHA
+        id: sha
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          SHA=$(git rev-parse "refs/tags/${TAG}^{commit}")
+          if ! [[ "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Could not resolve tag $TAG to a 40-char SHA (got: $SHA)"
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch bump-app to catalog
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CATALOG_DISPATCH_TOKEN }}
+          repository: ${{ env.CATALOG_REPO }}
+          event-type: bump-app
+          client-payload: |
+            {
+              "app_id": "${{ env.APP_ID }}",
+              "repository": "${{ env.APP_REPOSITORY }}",
+              "commit": "${{ steps.sha.outputs.sha }}",
+              "tag": "${{ github.event.release.tag_name }}",
+              "release_url": "${{ github.event.release.html_url }}"
+            }


### PR DESCRIPTION
## Summary

Sends a `repository_dispatch` to `dfguerrerom/sepal-apps-catalog` whenever a non-prerelease GitHub Release is published in this repo. The catalog then auto-opens a PR bumping this app's pinned commit SHA in `apps.test.json`.

The workflow:
- Triggers on `release: { types: [published] }`, skips pre-releases.
- Resolves the release tag to a 40-char commit SHA via `git rev-parse refs/tags/<tag>^{commit}` (handles annotated tags).
- Dispatches `{app_id, repository, commit, tag, release_url}` to the catalog using `peter-evans/repository-dispatch@v3`.

## Pre-merge requirement

- [x] `CATALOG_DISPATCH_TOKEN` secret available (org-level secret on `sepal-contrib`, scoped to this repo).

## Test plan

- [x] After merge, cut a throwaway release with a non-prerelease tag and verify the `Notify catalog of release` run succeeds, then verify a PR opens against `dfguerrerom/sepal-apps-catalog`.