### PR TITLE
perf(memory): run under jemalloc to bound RSS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ LABEL org.opencontainers.image.source="https://github.com/sepal-contrib/sepal_mg
 WORKDIR /usr/local/lib/mgci
 
 USER root
+# libjemalloc2: allocator for the runtime (see ENV block near the end).
 RUN apt-get update && apt-get install -y \
-    nano curl neovim supervisor netcat-openbsd net-tools git \
+    nano curl neovim supervisor netcat-openbsd net-tools git libjemalloc2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/* \
@@ -24,6 +25,18 @@ RUN micromamba create -n sepal_mgci python=3.10 pip -c conda-forge -y && \
     rm -rf ~/.cache/pip
 
 COPY . /usr/local/lib/mgci
+
+# Run under jemalloc so freed per-session memory returns to the OS. glibc/pymalloc
+# never release the arenas dented by per-session widget churn, so RSS ratchets to
+# the peak working set and stays there until restart; jemalloc purges free pages
+# on a decay timer, so memory follows users back down.
+# NOTE: if the .so is missing, LD_PRELOAD is silently ignored and PYTHONMALLOC=malloc
+# is worse than stock — after any image change verify jemalloc is actually loaded:
+#   grep -c jemalloc /proc/<app-python-pid>/maps   # >= 1
+# Placed after the build layers so image builds don't run under the preload.
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+    PYTHONMALLOC=malloc \
+    MALLOC_CONF=background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000
 
 EXPOSE 8766
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,11 @@ services:
       LOCAL_SEPAL_PASSWORD: "${LOCAL_SEPAL_PASSWORD:-}"
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "8766"]
-      timeout: 60s
-      interval: 1s
-      retries: 60
+      start_period: 60s
+      start_interval: 1s
+      interval: 20s
+      timeout: 5s
+      retries: 3
     networks:
       - sepal
     restart: always


### PR DESCRIPTION
Preload libjemalloc and set `PYTHONMALLOC=malloc` so freed per-session pages are returned to the OS via madvise decay, instead of glibc/pymalloc ratcheting RSS to the peak concurrent working set.

Mirrors the same change already in se.plan ('perf(memory): run under jemalloc to bound RSS').

**After building the image, verify jemalloc actually loaded** (a missing `.so` makes `PYTHONMALLOC=malloc` silently worse than stock):

```
grep -c jemalloc /proc/<app-python-pid>/maps   # >= 1
```